### PR TITLE
Add configuration for ocp-b.env-a

### DIFF
--- a/ocp-b.env-a/README.md
+++ b/ocp-b.env-a/README.md
@@ -1,7 +1,9 @@
 # OCP-B.ENV-A - Enterprise Deployment
 
 ## Enterprise OpenShift - OCP B
-_SaaS Deployment used to represent ocp "enterprise" deployment_
+
+Deployment consists of a base level of replicas for Pods. Database, redis and storage
+services are provided by external services.
 
 ## Topology
 
@@ -11,11 +13,36 @@ _SaaS Deployment used to represent ocp "enterprise" deployment_
 
 The **Enterprise OpenShift - AAP Operator Install** model consists of the following:
 
-| Component                                     | Pod count                      |
-| --------------------------------------------- | ------------------------------ |
-| AAP Gateway 2.5                               | 1                              |
-| Automation Controller 2.5                     | 2 *(task, web)*                |
-| Automation Hub 2.5                            | 5 *(api, content, web, 2 workers)* |
+| Component                                     | Pod count                                       |
+| --------------------------------------------- | ----------------------------------------------- |
+| AAP Gateway 2.5                               | 1                                               |
+| Automation Controller 2.5                     | 2 *(task, web)*                                 |
+| Automation Hub 2.5                            | 5 *(api, content, web, 2 workers)*              |
 | Event Driven Ansible 2.5                      | 5 *(api, activation, stream, scheduler,worker)* |
-| Database (external)                           | 1                              |
-| Redis Cache (external non-HA)                 | 1                              |
+| Mesh Ingress                                  | 1                                               |
+
+| External Components                           | Count                                           |
+| --------------------------------------------- | ----------------------------------------------- |
+| Database (external)                           | 1                                               |
+| Redis Cache (external non-HA)                 | 1                                               |
+| AWS S3 (example hub storage)                  | 1                                               |
+
+## Deployment Guide
+
+The platform is controled by an AnsibleAutomationPlatform custom resource found in (automation-platform.yaml)
+
+The secrets for the database and redis should be created before AnsibleAutomationPlatform resource is
+applied to the cluster.
+
+Example database secret is found in (automation-platform-postgres-configuration.yaml).
+Example redis secret is found in (automation-platform-redis-configuration.yaml).
+
+The secrets are example templates and need to be cloned and modified to produce the appropriate number of
+secrets for a proper installation.
+
+Automation hub has support for a variety of storage backends for exeuction environments and collections.
+Example storage secret is found in (automation-hub-storage.yaml).
+
+A single mesh ingress node is configured by the custom resource in (mesh-ingress.yaml).
+
+Refer to the production documentation for full details on configuration options.

--- a/ocp-b.env-a/automation-hub-storage.yaml
+++ b/ocp-b.env-a/automation-hub-storage.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: automation-hub-storage-secret
+  namespace: ansible-automation-platform
+type: Opaque
+data:
+  # This storage template demonstrates some of the parameters which
+  # can be used to configure storage for automation hub.
+
+  # Refer to the product documentation for details on the
+  # required fields and associated values.
+
+  # The fields below can be used to configure AWS S3 storage
+  s3-access-key-id: <access key encoded in base64>
+  s3-bucket-name: <bucket name encoded in base64>
+  s3-region: <region encoded in base64>
+  s3-secret-access-key: <secret access key encoded in base64>
+
+  # The fields below can be used to configure Azure storage
+  azure-account-key: <account key encoded in base64>
+  azure-account-name: <account name encoded in base64>
+  azure-container: <container name encoded in base64>
+  azure-container-path: <container path encoded in base64>
+  azure-connection-string: <connection string encoded in base64>
+immutable: false

--- a/ocp-b.env-a/automation-platform-postgres-configuration.yaml
+++ b/ocp-b.env-a/automation-platform-postgres-configuration.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/part-of: automation-platform
+  name: automation-platform-postgres-configuration  # Change this for each database secret
+  namespace: ansible-automation-platform
+type: Opaque
+data:
+  # The following field must be unique for each component: gateway, controller, hub, eda, etc.
+  database: <name of database encoded in base64>
+  host: <full qualifed hostname encoded in base64>
+  username: <username encoded in base64>  # Username can be the same for each database
+  password: <password encoded in base64>  # Password can be the same for each database
+  port: NTQzMg== # 5432
+  type: dW5tYW5hZ2Vk # unmanaged
+immutable: "False"

--- a/ocp-b.env-a/automation-platform-redis-configuration.yaml
+++ b/ocp-b.env-a/automation-platform-redis-configuration.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/part-of: automation-platform
+  name: automation-platform-redis-configuration # Change this for each redis secret
+  namespace: ansible-automation-platform
+type: Opaque
+data:
+  host: <fully qualifed hostname encoded in base64>
+  username: <username encoded in base64>
+  password: <password encoded in base64>
+  port: NjM3OQ== # 6379
+  redis_ca_cert_file: ""
+  redis_cert_file: ""
+  redis_key_file: ""
+  redis_mode: Y2x1c3Rlcg== # cluster
+  redis_ssl_cert_reqs: bm9uZQ== # none
+  redis_tls: dHJ1ZQ== # true
+  type: dW5tYW5hZ2Vk # unmanaged
+immutable: false

--- a/ocp-b.env-a/automation-platform.yaml
+++ b/ocp-b.env-a/automation-platform.yaml
@@ -1,0 +1,85 @@
+apiVersion: aap.ansible.com/v1alpha1
+kind: AnsibleAutomationPlatform
+metadata:
+  name: automation-platform
+  namespace: ansible-automation-platform
+spec:
+  redis:
+    redis_secret: automation-platform-redis-configuration
+    eda_redis_secret: automation-eda-redis-configuration
+  redis_mode: cluster
+  database:
+    database_secret: automation-platform-postgres-configuration
+  extra_settings:
+    - setting: REDIRECT_IS_HTTPS
+      value: 'True'
+  image_pull_policy: Always
+  image_pull_secrets:
+   - redhat-operators-pull-secret
+  route_host: platform.<application domain of OpenShift cluster>
+  service_type: NodePort
+  controller:
+    name: automation-controller
+    ee_extra_env: |
+      - name: RECEPTOR_KUBE_SUPPORT_RECONNECT
+        value: enabled
+    ee_images:
+      - name: Default execution environment
+        image: registry.redhat.io/ansible-automation-platform-25/ee-supported-rhel9:latest
+      - name: Minimal execution environment
+        image: registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel9:latest
+    ee_pull_credentials_secret: automation-controller-ee-pull-credentials
+    garbage_collect_secrets: false
+    image_pull_policy: IfNotPresent
+    ingress_type: none
+    ipv6_disabled: false
+    loadbalancer_ip: ""
+    loadbalancer_port: 80
+    loadbalancer_protocol: http
+    postgres_configuration_secret: automation-controller-postgres-configuration
+    service_type: NodePort
+    image_pull_secrets:
+      - redhat-operators-pull-secret
+    api_urlpattern_prefix: 'controller'
+    extra_settings:
+      - setting: AWX_RUNNER_KEEPALIVE_SECONDS
+        value: 240
+      - setting: ANSIBLE_BASE_JWT_KEY
+        value: '"http://automation-platform"'
+      - setting: ANSIBLE_BASE_JWT_REDIRECT_TYPE
+        value: '"awx"'
+      - setting: TOWER_URL_BASE
+        value: <value should match route_host setting>
+  hub:
+    name: automation-hub
+    postgres_configuration_secret: automation-hub-postgres-configuration
+    # The parameter below can change based on the type of storage used to support
+    # automation hub.
+    #
+    # Example to configure Azure blob storage:
+    # object_storage_azure_secret: automation-hub-storage-secret
+    object_storage_s3_secret: automation-hub-storage-secret
+    # Only ONE storage backend should be configured!
+    pulp_settings:
+      cache_enabled: false
+      redirect_to_object_storage: "False"
+      galaxy_collection_signing_service: ""
+      galaxy_container_signing_service: ""
+      token_auth_disabled: 'False'
+      token_signature_algorithm: 'ES256'
+      GALAXY_AUTHENTICATION_CLASSES:
+        - "galaxy_ng.app.auth.session.SessionAuthentication"
+        - "ansible_base.jwt_consumer.hub.auth.HubJWTAuth"
+        - "rest_framework.authentication.TokenAuthentication"
+        - "rest_framework.authentication.BasicAuthentication"
+      ANSIBLE_BASE_JWT_VALIDATE_CERT: True
+      ANSIBLE_BASE_JWT_KEY: 'http://automation-platform'
+      ANSIBLE_BASE_JWT_REDIRECT_TYPE: 'hub'
+    image_pull_secrets:
+      - redhat-operators-pull-secret
+  eda:
+    name: automation-eda
+    database:
+      database_secret: automation-eda-postgres-configuration
+    image_pull_secrets:
+      - redhat-operators-pull-secret

--- a/ocp-b.env-a/mesh-ingress.yaml
+++ b/ocp-b.env-a/mesh-ingress.yaml
@@ -1,0 +1,11 @@
+apiVersion: automationcontroller.ansible.com/v1alpha1
+kind: AutomationControllerMeshIngress
+metadata:
+  name: mesh-ingress-0  # Adjust the name here and below for each mesh ingress deployed
+  namespace: ansible-automation-platform
+spec:
+  deployment_name: automation-controller
+  external_hostname: mesh-ingress-0.<application domain of OpenShift cluster>
+  image_pull_secrets:
+  - redhat-operators-pull-secret
+  ingress_type: route

--- a/ocp-b.env-a/redhat-operators-pull-secret.yaml
+++ b/ocp-b.env-a/redhat-operators-pull-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: redhat-operators-pull-secret
+  namespace: ansible-automation-platform
+data:
+  .dockerconfigjson: # See kubernetes documentation for information on container pull secrets.
+immutable: false

--- a/ocp-b.env-a/redhat-operators-pull-secret.yaml
+++ b/ocp-b.env-a/redhat-operators-pull-secret.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+kind: Secret
 type: kubernetes.io/dockerconfigjson
 metadata:
   name: redhat-operators-pull-secret


### PR DESCRIPTION
This adds an example configuration for the OCP-B ENV-A topology. 

Review the README and notes within the files on how to customize the deployment.