### PR TITLE
chore: update ocp-b topology to include cluster_endpoint

### DIFF
--- a/ocp-b.env-a/automation-platform-redis-configuration.yaml
+++ b/ocp-b.env-a/automation-platform-redis-configuration.yaml
@@ -17,5 +17,7 @@ data:
   redis_mode: Y2x1c3Rlcg== # cluster
   redis_ssl_cert_reqs: bm9uZQ== # none
   redis_tls: dHJ1ZQ== # true
+  cluster_endpoint: <required if external redis service is a cluster> # format ":[,:]*"
   type: dW5tYW5hZ2Vk # unmanaged
 immutable: false
+


### PR DESCRIPTION
Since this example is referenced in the product docs, we need to include the cluster_endpoint option for customers who run external redis in cluster mode.